### PR TITLE
Add support for Environment variables for Unix

### DIFF
--- a/dist/preparser.js
+++ b/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/cat/dist/preparser.js
+++ b/packages/cat/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/cp/dist/preparser.js
+++ b/packages/cp/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/kill/dist/preparser.js
+++ b/packages/kill/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/ls/dist/preparser.js
+++ b/packages/ls/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/mkdir/dist/preparser.js
+++ b/packages/mkdir/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/mv/dist/preparser.js
+++ b/packages/mv/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/pwd/dist/preparser.js
+++ b/packages/pwd/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/rm/dist/preparser.js
+++ b/packages/rm/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/sort/dist/preparser.js
+++ b/packages/sort/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/packages/touch/dist/preparser.js
+++ b/packages/touch/dist/preparser.js
@@ -4,47 +4,53 @@ var os = require('os');
 var windows = os.platform() === 'win32';
 
 var preparser = function preparser(input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  var regex1 = undefined;
+  var regex2 = undefined;
   if (windows) {
-    (function () {
-      var roll = function roll(str) {
-        var match = /(\%.*?\%)/.exec(str);
-        if (match !== null) {
-          var string = match[0];
-          var sliceLength = parseFloat(string.length) + parseFloat(match.index);
-          var stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-          var value = undefined;
-          for (var name in process.env) {
-            if (process.env.hasOwnProperty(name)) {
-              if (String(name).toLowerCase() === stripped) {
-                value = process.env[name];
-              }
-            }
-          }
-          var prefix = undefined;
-          var suffix = undefined;
-          if (value) {
-            prefix = str.slice(0, sliceLength);
-            suffix = str.slice(sliceLength, str.length);
-            prefix = prefix.replace(string, value);
-          } else {
-            prefix = str.slice(0, sliceLength - 1);
-            suffix = str.slice(sliceLength - 1, str.length);
-          }
-          total += prefix;
-          return roll(suffix);
-        }
-        return str;
-      };
-
-      var total = '';
-
-      var remainder = roll(input);
-      total += remainder;
-      input = total;
-    })();
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
   }
+  var total = '';
+  function roll(str) {
+    var match = regex1.exec(str);
+    if (match !== null) {
+      var string = match[0];
+      var sliceLength = parseFloat(string.length) + parseFloat(match.index);
+      var stripped = String(string.replace(regex2, '')).toLowerCase();
+      var value = null;
+      for (var name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
+          }
+        }
+      }
+      var prefix = undefined;
+      var suffix = undefined;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
+    }
+    return str;
+  }
+  var remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 

--- a/src/preparser.js
+++ b/src/preparser.js
@@ -4,43 +4,53 @@ const os = require('os');
 const windows = (os.platform() === 'win32');
 
 const preparser = function (input) {
-  // On windows, replace out env variables.
+  // Replace out env variables.
   /* istanbul ignore next */
+  let regex1;
+  let regex2;
   if (windows) {
-    let total = '';
-    function roll(str) {
-      const match = /(\%.*?\%)/.exec(str);
-      if (match !== null) {
-        const string = match[0];
-        const sliceLength = (parseFloat(string.length) + parseFloat(match.index));
-        const stripped = String(string.replace(/^\%|\%$/g, '')).toLowerCase();
-        let value;
-        for (const name in process.env) {
-          if (process.env.hasOwnProperty(name)) {
-            if (String(name).toLowerCase() === stripped) {
-              value = process.env[name];
-            }
+    regex1 = /(\%.*?\%)/;
+    regex2 = /^\%|\%$/g;
+  } else {
+    regex1 = /(\${[^\$]*}|\$[^\$]*)/;
+    regex2 = /^\${|}$|^\$/g;
+  }
+  let total = '';
+  function roll(str) {
+    const match = regex1.exec(str);
+    if (match !== null) {
+      const string = match[0];
+      const sliceLength = (parseFloat(string.length) + parseFloat(match.index));
+      const stripped = String(string.replace(regex2, '')).toLowerCase();
+      let value = null;
+      for (const name in process.env) {
+        if (process.env.hasOwnProperty(name)) {
+          if (String(name).toLowerCase() === stripped) {
+            value = process.env[name];
+            break;
+          } else if (!windows) {
+            value = ''; // default to empty string on Unix
           }
         }
-        let prefix;
-        let suffix;
-        if (value) {
-          prefix = str.slice(0, sliceLength);
-          suffix = str.slice(sliceLength, str.length);
-          prefix = prefix.replace(string, value);
-        } else {
-          prefix = str.slice(0, sliceLength - 1);
-          suffix = str.slice(sliceLength - 1, str.length);
-        }
-        total += prefix;
-        return roll(suffix);
       }
-      return str;
+      let prefix;
+      let suffix;
+      if (value !== null) {
+        prefix = str.slice(0, sliceLength);
+        suffix = str.slice(sliceLength, str.length);
+        prefix = prefix.replace(string, value);
+      } else {
+        prefix = str.slice(0, sliceLength - 1);
+        suffix = str.slice(sliceLength - 1, str.length);
+      }
+      total += prefix;
+      return roll(suffix);
     }
-    const remainder = roll(input);
-    total += remainder;
-    input = total;
+    return str;
   }
+  const remainder = roll(input);
+  total += remainder;
+  input = total;
   return input;
 };
 


### PR DESCRIPTION
This is related to #22. I noticed that ced6ce6233ebeaa6fa3a82248df83547991fb665 adds support for Windows environment variables, but not for Unix environment variables. This should add that support (although it's not perfect).

On Unix, if you reference a variable that doesn't exist, it usually defaults to the empty string. So `echo $FOO` would normally print the empty string. I wrote this to parse similarly.

This supports the syntax `echo $PATH` and `echo ${PATH}`. It doesn't do any of the tricky [string manipulation syntax bash offers](http://www.tldp.org/LDP/abs/html/string-manipulation.html) though.

I didn't add any tests because I wasn't sure where to add them. If you could point me toward the right spot, I can add those back in. Also, if there's any other issues, I'll gladly do my best to address them.