### PR TITLE
Improve recognizing variable references. Add tests

### DIFF
--- a/dist/preparser.js
+++ b/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/cat/dist/preparser.js
+++ b/packages/cat/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/cp/dist/preparser.js
+++ b/packages/cp/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/kill/dist/preparser.js
+++ b/packages/kill/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/ls/dist/preparser.js
+++ b/packages/ls/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/mkdir/dist/preparser.js
+++ b/packages/mkdir/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/mv/dist/preparser.js
+++ b/packages/mv/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/pwd/dist/preparser.js
+++ b/packages/pwd/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/rm/dist/preparser.js
+++ b/packages/rm/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/sort/dist/preparser.js
+++ b/packages/sort/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/touch/dist/preparser.js
+++ b/packages/touch/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/src/preparser.js
+++ b/src/preparser.js
@@ -7,7 +7,7 @@ const windows = (os.platform() === 'win32');
 const parseEnvVariables = function (input) {
   const regex1 = (windows) ?
     /(\%.*?\%)/ :
-    /(\${[^\$]*}|\$[^\$]*)/;
+    /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   const regex2 = (windows) ?
     /^\%|\%$/g :
     /^\${|}$|^\$/g;

--- a/test/preparser.js
+++ b/test/preparser.js
@@ -10,6 +10,7 @@ const preparser = require('../dist/preparser.js');
 
 const windows = (os.platform() === 'win32');
 const path = process.env.PATH;
+const nvmDir = process.env.NVM_DIR;
 
 describe('preparser', function () {
   it('should exist and be a function', function () {
@@ -37,7 +38,63 @@ describe('preparser', function () {
       }
     });
 
-    it.skip('should convert the same variable twice', function () {
+    it('concatenate variables with no space', function () {
+      if (windows) {
+        cash('echo %PATH%%PATH%').should.equal(`${path}${path}\n`);
+      } else {
+        cash('echo $PATH$PATH').should.equal(`${path}${path}\n`);
+      }
+    });
+
+    it('display variables with one or more spaces in between', function () {
+      if (windows) {
+        cash('echo %PATH% %PATH%').should.equal(`${path} ${path}\n`);
+      } else {
+        cash('echo $PATH $PATH').should.equal(`${path} ${path}\n`);
+      }
+    });
+
+    it('display variable references from inside double quotes', function () {
+      if (windows) {
+        cash('echo "%PATH%   %PATH%"').should.equal(`${path}   ${path}\n`);
+      } else {
+        cash('echo "$PATH   $PATH"').should.equal(`${path}   ${path}\n`);
+      }
+    });
+
+    it('separate variable references from strings with slash or dot', function () {
+      if (windows) {
+        cash('echo foo/%PATH%/%PATH%.bar').should.equal(`foo/${path}/${path}.bar\n`);
+      } else {
+        cash('echo foo/$PATH/$PATH.bar').should.equal(`foo/${path}/${path}.bar\n`);
+      }
+    });
+
+    it('non-existent variables default to the empty string for unix', function () {
+      if (!windows) {
+        cash('echo $FAKE_ENV_VAR').should.equal('\n');
+      }
+    });
+
+    it('underscores can be in environmental variable names', function () {
+      if (nvmDir) {
+        if (windows) {
+          cash('echo %NVM_DIR%').should.equal(`${nvmDir}\n`);
+        } else {
+          cash('echo $NVM_DIR').should.equal(`${nvmDir}\n`);
+        }
+      }
+    });
+
+    it('append variables and strings', function () {
+      if (windows) {
+        cash('echo foo%PATH%bar').should.equal(`foo${path}bar\n`);
+      } else {
+        cash('echo foo${PATH}bar').should.equal(`foo${path}bar\n`);
+      }
+    });
+
+    it('should convert the same variable twice', function () {
       if (windows) {
         cash('echo %PATH%-%PATH%').should.equal(`${path}-${path}\n`);
       } else {


### PR DESCRIPTION
This fixes a bug in #34 and adds in more tests. Let me know if you think of any more tests we should add in.

If you're ok with modifying the environment for the tests, then we could add in a test to make sure that variables like `FOO="this has    spaces"` get treated properly when referenced.