### PR TITLE
Only use unix-style variable references

### DIFF
--- a/dist/preparser.js
+++ b/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/dist/preparser.js
+++ b/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/dist/preparser.js
+++ b/dist/preparser.js
@@ -5,41 +5,27 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
-  var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
-  var total = '';
-  function iterate(str) {
-    var match = regex1.exec(str);
-    if (match !== null) {
-      var string = match[0];
-      var stripped = String(string.replace(regex2, '')).toLowerCase();
-      var value = null;
+  return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
+    var varName = capture1 || capture2 || capture3;
+    var value = '';
+    if (windows) {
       for (var name in process.env) {
         if (process.env.hasOwnProperty(name)) {
-          if (String(name).toLowerCase() === stripped) {
+          // Windows is case insensitive
+          if (String(name).toLowerCase() === varName.toLowerCase()) {
             value = process.env[name];
             break;
-          } else if (!windows) {
-            value = ''; // default to empty string on Unix
           }
         }
       }
-      var sliceLength = parseFloat(string.length) + parseFloat(match.index) - (value !== null ? 0 : 1);
-      var prefix = str.slice(0, sliceLength);
-      var suffix = str.slice(sliceLength, str.length);
-      if (value !== null) {
-        prefix = prefix.replace(string, value);
-      }
-      total += prefix;
-      return iterate(suffix);
+    } else {
+      // default to empty string on Unix
+      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
     }
-    return str;
-  }
-
-  var out = iterate(input);
-  total += out;
-  return total;
+    return value;
+  });
 };
 
 var preparser = function preparser(input) {

--- a/packages/cat/dist/preparser.js
+++ b/packages/cat/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/cat/dist/preparser.js
+++ b/packages/cat/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/cat/dist/preparser.js
+++ b/packages/cat/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/cp/dist/preparser.js
+++ b/packages/cp/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/cp/dist/preparser.js
+++ b/packages/cp/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/cp/dist/preparser.js
+++ b/packages/cp/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/kill/dist/preparser.js
+++ b/packages/kill/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/kill/dist/preparser.js
+++ b/packages/kill/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/kill/dist/preparser.js
+++ b/packages/kill/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/ls/dist/preparser.js
+++ b/packages/ls/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/ls/dist/preparser.js
+++ b/packages/ls/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/ls/dist/preparser.js
+++ b/packages/ls/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/mkdir/dist/preparser.js
+++ b/packages/mkdir/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/mkdir/dist/preparser.js
+++ b/packages/mkdir/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/mkdir/dist/preparser.js
+++ b/packages/mkdir/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/mv/dist/preparser.js
+++ b/packages/mv/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/mv/dist/preparser.js
+++ b/packages/mv/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/mv/dist/preparser.js
+++ b/packages/mv/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/pwd/dist/preparser.js
+++ b/packages/pwd/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/pwd/dist/preparser.js
+++ b/packages/pwd/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/pwd/dist/preparser.js
+++ b/packages/pwd/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/rm/dist/preparser.js
+++ b/packages/rm/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/rm/dist/preparser.js
+++ b/packages/rm/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/rm/dist/preparser.js
+++ b/packages/rm/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/sort/dist/preparser.js
+++ b/packages/sort/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/sort/dist/preparser.js
+++ b/packages/sort/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/sort/dist/preparser.js
+++ b/packages/sort/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/packages/touch/dist/preparser.js
+++ b/packages/touch/dist/preparser.js
@@ -5,10 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var referenceRegex = /%(.*)%|\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-  // = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-  var winRefRegex = /\%.*?\%/;
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;

--- a/packages/touch/dist/preparser.js
+++ b/packages/touch/dist/preparser.js
@@ -5,7 +5,7 @@ var windows = os.platform() === 'win32';
 
 // Replace out env variables.
 var parseEnvVariables = function parseEnvVariables(input) {
-  var regex1 = windows ? /(\%.*?\%)/ : /(\${[^\$]*}|\$[^\$]*)/;
+  var regex1 = windows ? /(\%.*?\%)/ : /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   var regex2 = windows ? /^\%|\%$/g : /^\${|}$|^\$/g;
 
   var total = '';

--- a/packages/touch/dist/preparser.js
+++ b/packages/touch/dist/preparser.js
@@ -1,30 +1,14 @@
 'use strict';
 
-var os = require('os');
-var windows = os.platform() === 'win32';
-
 // Replace out env variables.
+
 var parseEnvVariables = function parseEnvVariables(input) {
   var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     var varName = capture1 || capture2 || capture3;
-    var value = '';
-    if (windows) {
-      for (var name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/src/preparser.js
+++ b/src/preparser.js
@@ -5,45 +5,28 @@ const windows = (os.platform() === 'win32');
 
 // Replace out env variables.
 const parseEnvVariables = function (input) {
-  const regex1 = (windows) ?
-    /(\%.*?\%)/ :
-    /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
-  const regex2 = (windows) ?
-    /^\%|\%$/g :
-    /^\${|}$|^\$/g;
+  const referenceRegex =
+    /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
-  let total = '';
-  function iterate(str) {
-    const match = regex1.exec(str);
-    if (match !== null) {
-      const string = match[0];
-      const stripped = String(string.replace(regex2, '')).toLowerCase();
-      let value = null;
+  return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
+    const varName = capture1 || capture2 || capture3;
+    let value = '';
+    if (windows) {
       for (const name in process.env) {
         if (process.env.hasOwnProperty(name)) {
-          if (String(name).toLowerCase() === stripped) {
+          // Windows is case insensitive
+          if (String(name).toLowerCase() === varName.toLowerCase()) {
             value = process.env[name];
             break;
-          } else if (!windows) {
-            value = ''; // default to empty string on Unix
           }
         }
       }
-      const sliceLength = ((parseFloat(string.length) + parseFloat(match.index)) - ((value !== null) ? 0 : 1));
-      let prefix = str.slice(0, sliceLength);
-      const suffix = str.slice(sliceLength, str.length);
-      if (value !== null) {
-        prefix = prefix.replace(string, value);
-      }
-      total += prefix;
-      return iterate(suffix);
+    } else {
+      // default to empty string on Unix
+      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
     }
-    return str;
-  }
-
-  const out = iterate(input);
-  total += out;
-  return total;
+    return value;
+  });
 };
 
 const preparser = function (input) {

--- a/src/preparser.js
+++ b/src/preparser.js
@@ -7,7 +7,7 @@ const windows = (os.platform() === 'win32');
 const parseEnvVariables = function (input) {
   const regex1 = (windows) ?
     /(\%.*?\%)/ :
-    /(\${[^\$]*}|\$[^\$]*)/;
+    /(\${[a-zA-Z_][a-zA-Z0-9_]*}|\$[a-zA-Z_][a-zA-Z0-9_]*)/;
   const regex2 = (windows) ?
     /^\%|\%$/g :
     /^\${|}$|^\$/g;

--- a/src/preparser.js
+++ b/src/preparser.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const os = require('os');
-const windows = (os.platform() === 'win32');
-
 // Replace out env variables.
 const parseEnvVariables = function (input) {
   const referenceRegex =
@@ -10,22 +7,8 @@ const parseEnvVariables = function (input) {
 
   return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
     const varName = capture1 || capture2 || capture3;
-    let value = '';
-    if (windows) {
-      for (const name in process.env) {
-        if (process.env.hasOwnProperty(name)) {
-          // Windows is case insensitive
-          if (String(name).toLowerCase() === varName.toLowerCase()) {
-            value = process.env[name];
-            break;
-          }
-        }
-      }
-    } else {
-      // default to empty string on Unix
-      value = process.env.hasOwnProperty(varName) ? process.env[varName] : '';
-    }
-    return value;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
   });
 };
 

--- a/test/preparser.js
+++ b/test/preparser.js
@@ -10,6 +10,7 @@ const preparser = require('../dist/preparser.js');
 
 const windows = (os.platform() === 'win32');
 const path = process.env.PATH;
+const nvmDir = process.env.NVM_DIR;
 
 describe('preparser', function () {
   it('should exist and be a function', function () {
@@ -37,7 +38,63 @@ describe('preparser', function () {
       }
     });
 
-    it.skip('should convert the same variable twice', function () {
+    it('concatenate variables with no space', function () {
+      if (windows) {
+        cash('echo %PATH%%PATH%').should.equal(`${path}${path}\n`);
+      } else {
+        cash('echo $PATH$PATH').should.equal(`${path}${path}\n`);
+      }
+    });
+
+    it('display variables with one or more spaces in between', function () {
+      if (windows) {
+        cash('echo %PATH% %PATH%').should.equal(`${path} ${path}\n`);
+      } else {
+        cash('echo $PATH $PATH').should.equal(`${path} ${path}\n`);
+      }
+    });
+
+    it('display variable references from inside double quotes', function () {
+      if (windows) {
+        cash('echo "%PATH%   %PATH%"').should.equal(`${path}   ${path}\n`);
+      } else {
+        cash('echo "$PATH   $PATH"').should.equal(`${path}   ${path}\n`);
+      }
+    });
+
+    it('separate variable references from strings with slash or dot', function () {
+      if (windows) {
+        cash('echo foo/%PATH%/%PATH%.bar').should.equal(`foo/${path}/${path}.bar\n`);
+      } else {
+        cash('echo foo/$PATH/$PATH.bar').should.equal(`foo/${path}/${path}.bar\n`);
+      }
+    });
+
+    it('non-existent variables default to the empty string for unix', function () {
+      if (!windows) {
+        cash('echo $FAKE_ENV_VAR').should.equal('\n');
+      }
+    });
+
+    it('underscores can be in environmental variable names', function () {
+      if (nvmDir) {
+        if (windows) {
+          cash('echo %NVM_DIR%').should.equal(`${nvmDir}\n`);
+        } else {
+          cash('echo $NVM_DIR').should.equal(`${nvmDir}\n`);
+        }
+      }
+    });
+
+    it('append variables and strings', function () {
+      if (windows) {
+        cash('echo foo%PATH%bar').should.equal(`foo${path}bar\n`);
+      } else {
+        cash('echo foo${PATH}bar').should.equal(`foo${path}bar\n`);
+      }
+    });
+
+    it('should convert the same variable twice', function () {
       if (windows) {
         cash('echo %PATH%-%PATH%').should.equal(`${path}-${path}\n`);
       } else {

--- a/test/preparser.js
+++ b/test/preparser.js
@@ -31,7 +31,7 @@ describe('preparser', function () {
 
   describe('environmental variables', function () {
     before(function () {
-      process.env.FOO = 'This*string\'has $pecial${characters}';
+      process.env.FOO = 'This*string\'has   $pecial${characters}';
     });
     it('should convert simple variable references', function () {
       cash('echo $PATH').should.equal(`${path}\n`);
@@ -84,7 +84,7 @@ describe('preparser', function () {
     });
 
     it('should handle variables with weird characters inside', function () {
-      cash('echo $FOO').should.equal(`${process.env.FOO}\n`);
+      cash('echo "$FOO"').should.equal(`${process.env.FOO}\n`);
     });
 
     it('should convert the same variable twice', function () {

--- a/test/preparser.js
+++ b/test/preparser.js
@@ -30,76 +30,68 @@ describe('preparser', function () {
   });
 
   describe('environmental variables', function () {
-    it('should convert them according to os', function () {
-      if (windows) {
-        cash('echo %PATH%').should.equal(`${path}\n`);
-      } else {
-        cash('echo $PATH').should.equal(`${path}\n`);
-      }
+    before(function () {
+      process.env.FOO = 'This*string\'has $pecial${characters}';
+    });
+    it('should convert simple variable references', function () {
+      cash('echo $PATH').should.equal(`${path}\n`);
     });
 
-    it('concatenate variables with no space', function () {
-      if (windows) {
-        cash('echo %PATH%%PATH%').should.equal(`${path}${path}\n`);
-      } else {
-        cash('echo $PATH$PATH').should.equal(`${path}${path}\n`);
-      }
+    it('should convert variable references using the ${.*} syntax', function () {
+      cash('echo ${PATH}').should.equal(`${path}\n`);
     });
 
-    it('display variables with one or more spaces in between', function () {
-      if (windows) {
-        cash('echo %PATH% %PATH%').should.equal(`${path} ${path}\n`);
-      } else {
-        cash('echo $PATH $PATH').should.equal(`${path} ${path}\n`);
-      }
+    it('should concatenate variables with no space', function () {
+      cash('echo $PATH$PATH').should.equal(`${path}${path}\n`);
+      cash('echo ${PATH}${PATH}').should.equal(`${path}${path}\n`);
     });
 
-    it('display variable references from inside double quotes', function () {
-      if (windows) {
-        cash('echo "%PATH%   %PATH%"').should.equal(`${path}   ${path}\n`);
-      } else {
-        cash('echo "$PATH   $PATH"').should.equal(`${path}   ${path}\n`);
-      }
+    it('should display variables with one or more spaces in between', function () {
+      cash('echo $PATH $PATH').should.equal(`${path} ${path}\n`);
+      cash('echo ${PATH} ${PATH}').should.equal(`${path} ${path}\n`);
     });
 
-    it('separate variable references from strings with slash or dot', function () {
-      if (windows) {
-        cash('echo foo/%PATH%/%PATH%.bar').should.equal(`foo/${path}/${path}.bar\n`);
-      } else {
-        cash('echo foo/$PATH/$PATH.bar').should.equal(`foo/${path}/${path}.bar\n`);
-      }
+    it('should display variable references from inside double quotes', function () {
+      cash('echo "$PATH   $PATH"').should.equal(`${path}   ${path}\n`);
     });
 
-    it('non-existent variables default to the empty string for unix', function () {
-      if (!windows) {
-        cash('echo $FAKE_ENV_VAR').should.equal('\n');
-      }
+    it('should separate variable references from strings with slash or dot', function () {
+      cash('echo foo/$PATH/$PATH.bar').should.equal(`foo/${path}/${path}.bar\n`);
     });
 
-    it('underscores can be in environmental variable names', function () {
+    it('should show non-existent variables as the empty string', function () {
+      cash('echo $FAKE_ENV_VAR').should.equal('\n');
+    });
+
+    it('should allow underscores in environmental variable names', function () {
       if (nvmDir) {
-        if (windows) {
-          cash('echo %NVM_DIR%').should.equal(`${nvmDir}\n`);
-        } else {
-          cash('echo $NVM_DIR').should.equal(`${nvmDir}\n`);
-        }
+        cash('echo $NVM_DIR').should.equal(`${nvmDir}\n`);
       }
     });
 
-    it('append variables and strings', function () {
+    it('should append variables and strings', function () {
+      cash('echo foo${PATH}bar').should.equal(`foo${path}bar\n`);
+    });
+
+    it('should have proper case sensitivity', function () {
       if (windows) {
-        cash('echo foo%PATH%bar').should.equal(`foo${path}bar\n`);
+        // Case insensitive
+        cash('echo %path%.%PATH%').should.equal(`${path}.${path}\n`);
       } else {
-        cash('echo foo${PATH}bar').should.equal(`foo${path}bar\n`);
+        // Case sensitive
+        cash('echo $path.$PATH').should.equal(`.${path}\n`);
       }
+    });
+
+    it('should handle variables with weird characters inside', function () {
+      cash('echo $FOO').should.equal(`${process.env.FOO}\n`);
     });
 
     it('should convert the same variable twice', function () {
-      if (windows) {
-        cash('echo %PATH%-%PATH%').should.equal(`${path}-${path}\n`);
-      } else {
-        cash('echo $PATH-$PATH').should.equal(`${path}-${path}\n`);
-      }
+      cash('echo $PATH-$PATH').should.equal(`${path}-${path}\n`);
+    });
+    after(function () {
+      delete process.env.FOO;
     });
   });
 });

--- a/test/preparser.js
+++ b/test/preparser.js
@@ -76,7 +76,7 @@ describe('preparser', function () {
     it('should have proper case sensitivity', function () {
       if (windows) {
         // Case insensitive
-        cash('echo %path%.%PATH%').should.equal(`${path}.${path}\n`);
+        cash('echo $path.$PATH').should.equal(`${path}.${path}\n`);
       } else {
         // Case sensitive
         cash('echo $path.$PATH').should.equal(`.${path}\n`);


### PR DESCRIPTION
This is different than the direction that was decided on in #34 (see [comment](https://github.com/dthree/cash/pull/34#issuecomment-189713677)), but I think this might work out better in the long run (for posix compatibility). I opted to make this a separate pull request (rather than tack on to #37) since this is a very different approach.

This means things like `%PATH%` always evaluate to the literal `%PATH%`, while references of the style `$PATH` or `${PATH}` evaluate to the value of the variable (or the empty string if this variable doesn't exist).

The main advantages of this are:

 1. It's (mostly) consistent with POSIX (so `echo %path%` is guaranteed to be the literal value in both cash and bash)
 2. This is a shorter implementation, and (IMO) easier to understand
 3. It *probably* performs slightly better on Unix systems (I haven't tested this, so I can't confirm)
 4. Case sensitive variable names for Unix, case *insensitive* names for Windows (so either `$PATH` or `$path` work on Windows)

This means that really tricky windows-specific examples (like `echo hi%invalid%computername%username%username%%%`) aren't really going to have support (I can't think of an equivalent bash syntax that would have the same semantics). So, this is a tradeoff, but I think it's one that's probably worth discussing. And if POSIX compatibility is the goal, you probably won't need to support the other behavior.