### PR TITLE
Fix bug related to ShellJS v0.6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('packages', function () {
       $.cp('-f', help, `${dir}/${help}`);
       $.cp('-f', preparser, `${dir}/${preparser}`);
       $.cp('-f', './bin/parser.js', `${dir}/bin/parser.js`);
-      $.cp('-fr', `./packages/template.README.md`, `${dir}/README.md`);
+      $.cp('-f', `./packages/template.README.md`, `${dir}/README.md`);
       let readme = String($.cat(`${dir}/README.md`));
       readme = readme.replace(/\{package\-name\}/g, `cash-${name}`);
       readme = readme.replace(/\{command\-name\}/g, `${name}`);


### PR DESCRIPTION
I was working on a couple new commands and I realized they wouldn't get packaged properly. The culprit? ShellJS...

shelljs/shelljs#376 was opened two days ago, and it's related to this I think. I believe this bug was introduced in `v0.6`.

I'll fix the bug in ShellJS, but this PR is a good enough workaround for the purposes of Cash.