### PR TITLE
New commands: true and false

### DIFF
--- a/bin/false.js
+++ b/bin/false.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./parser')(process.argv, 'false');

--- a/bin/true.js
+++ b/bin/true.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./parser')(process.argv, 'true');

--- a/commands.json
+++ b/commands.json
@@ -6,6 +6,7 @@
     "cp",
     "echo",
     "export",
+    "false",
     "kill",
     "ls",
     "mkdir",
@@ -13,6 +14,7 @@
     "pwd",
     "sort",
     "touch",
+    "true",
     "cat",
     "less",
     "grep",
@@ -71,6 +73,12 @@
         "./dist/util/interfacer.js"
       ]
     },
+    "false": {
+      "dependencies": [],
+      "files": [
+        "./dist/util/interfacer.js"
+      ]
+    },
     "kill": {
       "dependencies": ["fkill", "lodash"],
       "files": [
@@ -125,6 +133,12 @@
       "files": [
         "./dist/util/interfacer.js",
         "./dist/lib/sugar.js"
+      ]
+    },
+    "true": {
+      "dependencies": [],
+      "files": [
+        "./dist/util/interfacer.js"
       ]
     },
     "rm": {

--- a/dist/commands/false.js
+++ b/dist/commands/false.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var interfacer = require('./../util/interfacer');
+
+var _false = {
+  exec: function exec() {
+    // Always return 1
+    return 1;
+  }
+};
+
+module.exports = function (vorpal) {
+  if (vorpal === undefined) {
+    return _false;
+  }
+  vorpal.api.false = _false;
+  vorpal.command('false').action(function (args, callback) {
+    return interfacer.call(this, {
+      command: _false,
+      callback: callback
+    });
+  });
+};

--- a/dist/commands/true.js
+++ b/dist/commands/true.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var interfacer = require('./../util/interfacer');
+
+var _true = {
+  exec: function exec() {
+    // Always return 0
+    return 0;
+  }
+};
+
+module.exports = function (vorpal) {
+  if (vorpal === undefined) {
+    return _true;
+  }
+  vorpal.api.true = _true;
+  vorpal.command('true').action(function (args, callback) {
+    return interfacer.call(this, {
+      command: _true,
+      callback: callback
+    });
+  });
+};

--- a/dist/help.js
+++ b/dist/help.js
@@ -2,7 +2,7 @@
 
 var pad = require('./util/pad');
 
-var commands = ['alias [-p] [name=[value]]', 'cat [-AbeEnstTv] [files ...]', 'cd [dir]', 'clear', 'cp [-fnr] source ... dest', 'echo [-eE] [arg ...]', 'export [-p][id=[value]]', 'grep [-bHhinqsvw] [-m max] [--silent] [--include pattern] pattern [files ...]', 'kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l', 'less [files ...]', 'ls [-aAdFhilQrRStUwx1] [paths ...]', 'mkdir [-pv] [directories ...]', 'mv [-fnv] source ... dest', 'pwd [files ...]', 'rm [-frR] [files ...]', 'sort [-chMnrR] [-o file] [files ...]', 'touch [-acm] [-d date] [-r ref] [--time word] file ...', 'unalias [-a] name [names ...]'];
+var commands = ['alias [-p] [name=[value]]', 'cat [-AbeEnstTv] [files ...]', 'cd [dir]', 'clear', 'cp [-fnr] source ... dest', 'echo [-eE] [arg ...]', 'export [-p][id=[value]]', 'false', 'grep [-bHhinqsvw] [-m max] [--silent] [--include pattern] pattern [files ...]', 'kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l', 'less [files ...]', 'ls [-aAdFhilQrRStUwx1] [paths ...]', 'mkdir [-pv] [directories ...]', 'mv [-fnv] source ... dest', 'pwd [files ...]', 'rm [-frR] [files ...]', 'sort [-chMnrR] [-o file] [files ...]', 'touch [-acm] [-d date] [-r ref] [--time word] file ...', 'true', 'unalias [-a] name [names ...]'];
 
 function chop(str, len) {
   var res = String(str).slice(0, len - 2);

--- a/dist/help/false.js
+++ b/dist/help/false.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = "\nUsage: false [OPTION]\nDo nothing, unsuccessfully\n\nThis command simply exits with status 1 (failure).\n\n      --help   display this help and exit\n\nReport export bugs to <https://github.com/dthree/cash>\nCash home page: <http://cash.js.org/>\n";

--- a/dist/help/true.js
+++ b/dist/help/true.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = "\nUsage: true [OPTION]\nDo nothing, successfully\n\nThis command simply exits with status zero (success).\n\n      --help   display this help and exit\n\nReport export bugs to <https://github.com/dthree/cash>\nCash home page: <http://cash.js.org/>\n";

--- a/packages/cat/README.md
+++ b/packages/cat/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/cp/README.md
+++ b/packages/cp/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/false/README.md
+++ b/packages/false/README.md
@@ -1,20 +1,20 @@
-# cash-kill
+# cash-false
 
 ---
 
 
-This is a cross-platform, 100% ES6 implementation of the Unix `kill` command.
+This is a cross-platform, 100% ES6 implementation of the Unix `false` command.
 
 ```bash
-npm install cash-kill -g
+npm install cash-false -g
 ```
 
-This will install `kill` globally in your system path.
+This will install `false` globally in your system path.
 
 For help on the command, type:
 
 ```bash
-> kill --help
+> false --help
 ```
 
 ## More

--- a/packages/false/bin/false.js
+++ b/packages/false/bin/false.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./parser')(process.argv, 'false');

--- a/packages/false/bin/parser.js
+++ b/packages/false/bin/parser.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = function (args, command) {
+  args.splice(0, 2);
+  var pipes = (args.indexOf('|') > -1);
+  if (args.length === 0) {
+    // If we don't have to parse arguments, do
+    // the quickest load: just the raw js file
+    // of the command and nothing else.
+    var cmd = require('./../dist/commands/' + command)();
+    cmd.exec.call(console, {options: {}}, {});
+  } else if (pipes === false) {
+    // If we need to parse args for this
+    // command only, pull up vorpal and just load
+    // that one command.
+    var vorpal = require('vorpal')();
+    vorpal.api = {};
+    require('./../dist/commands/' + command)(vorpal);
+    args = args.join(' ');
+
+    // If we passed in a help request, load in
+    // the help file.
+    if (args.indexOf('help') > -1 || args.indexOf('?') > -1) {
+      let help;
+      try {
+        help = require('./../dist/help/' + command + '.js');
+        help = String(help).replace(/^\n|\n$/g, '');
+      } catch (e) {}
+      let cmdObj = vorpal.find(command);
+      if (cmdObj && help) {
+        cmdObj.help(function (argus, cb) {
+          cb(help);
+        })
+      }
+    }
+    vorpal.exec(command + ' ' + args);
+  } else {
+    // If we get into piping other commands,
+    // we need to go full bore and load the
+    // entire cash library.
+    // I guess we could technically parse all
+    // of the passed args, look for applicable
+    // commands and only load those, but that's
+    // some messy work for something that might
+    // not matter. If you're reading this and
+    // have deemed it matters, do a PR.
+    var cash = require('./../dist/index');
+    cash.vorpal.exec(command + ' ' + args.join(' '));
+  }
+};

--- a/packages/false/dist/commands/false.js
+++ b/packages/false/dist/commands/false.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var interfacer = require('./../util/interfacer');
+
+var _false = {
+  exec: function exec() {
+    // Always return 1
+    return 1;
+  }
+};
+
+module.exports = function (vorpal) {
+  if (vorpal === undefined) {
+    return _false;
+  }
+  vorpal.api.false = _false;
+  vorpal.command('false').action(function (args, callback) {
+    return interfacer.call(this, {
+      command: _false,
+      callback: callback
+    });
+  });
+};

--- a/packages/false/dist/help/false.js
+++ b/packages/false/dist/help/false.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = "\nUsage: false [OPTION]\nDo nothing, unsuccessfully\n\nThis command simply exits with status 1 (failure).\n\n      --help   display this help and exit\n\nReport export bugs to <https://github.com/dthree/cash>\nCash home page: <http://cash.js.org/>\n";

--- a/packages/false/dist/preparser.js
+++ b/packages/false/dist/preparser.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Replace out env variables.
+
+var parseEnvVariables = function parseEnvVariables(input) {
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+  return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
+    var varName = capture1 || capture2 || capture3;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
+  });
+};
+
+var preparser = function preparser(input) {
+  input = parseEnvVariables(input);
+  return input;
+};
+
+module.exports = preparser;

--- a/packages/false/dist/util/interfacer.js
+++ b/packages/false/dist/util/interfacer.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Simple binding interface between
+ * each command's function and the caller
+ * of the command, whether by `cash.command`
+ * or by being invoked by Vorpal.
+ * This exists to abstract complexity
+ * and create a standard in interfacing
+ * commands acorss muliple execution paths.
+ *
+ * @param {Object} opt
+ * @api public
+ */
+
+module.exports = function (opt) {
+  var self = this;
+  var stdout = '';
+  opt.options = opt.options || {};
+  opt.callback = opt.callback || function () {};
+  opt.command = opt.command || {
+    exec: function exec() {}
+  };
+
+  var logger = {
+    log: function log(out) {
+      stdout += out + '\n';
+      if (opt.silent !== true) {
+        // process.stdout.write(out) // to do - handle newline problem.
+        self.log(out);
+      }
+    }
+  };
+
+  function onResult(result) {
+    result = result === undefined ? 0 : result;
+    opt.callback(null, stdout);
+    return stdout;
+  }
+
+  if (opt.async === true) {
+    return opt.command.exec.call(logger, opt.args, opt.options, onResult);
+  }
+  return onResult(opt.command.exec.call(logger, opt.args, opt.options));
+};

--- a/packages/false/package.json
+++ b/packages/false/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "cash-false",
+  "version": "0.0.1",
+  "description": "Cross-platform implementation of the Unix 'false' command.",
+  "main": "./dist/commands/false.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dthree/cash.git"
+  },
+  "keywords": [
+    "cash",
+    "terminal",
+    "emulator",
+    "cygwin",
+    "cli",
+    "windows",
+    "linux",
+    "unix",
+    "posix",
+    "bash",
+    "tty",
+    "util",
+    "vorpal",
+    "vorpal.js"
+  ],
+  "author": "dthree",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/dthree/cash/issues"
+  },
+  "homepage": "https://github.com/dthree/cash#readme",
+  "devDependencies": {},
+  "bin": {
+    "false": "./bin/false.js"
+  },
+  "dependencies": {
+    "vorpal": "^1.9.7"
+  },
+  "engines": {
+    "node": ">= 4",
+    "iojs": ">= 1.0.0"
+  },
+  "files": [
+    "dist",
+    "bin"
+  ]
+}

--- a/packages/ls/README.md
+++ b/packages/ls/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/mkdir/README.md
+++ b/packages/mkdir/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/mv/README.md
+++ b/packages/mv/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/pwd/README.md
+++ b/packages/pwd/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/rm/README.md
+++ b/packages/rm/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/sort/README.md
+++ b/packages/sort/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/touch/README.md
+++ b/packages/touch/README.md
@@ -32,6 +32,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 
 - [cash-cat](https://npmjs.com/package/cash-cat)
 - [cash-cp](https://npmjs.com/package/cash-cp)
+- [cash-false](https://npmjs.com/package/cash-false)
 - [cash-kill](https://npmjs.com/package/cash-kill)
 - [cash-ls](https://npmjs.com/package/cash-ls)
 - [cash-mkdir](https://npmjs.com/package/cash-mkdir)
@@ -39,6 +40,7 @@ This module is part of [Cash](https://github.com/dthree/cash), a project providi
 - [cash-pwd](https://npmjs.com/package/cash-pwd)
 - [cash-sort](https://npmjs.com/package/cash-sort)
 - [cash-touch](https://npmjs.com/package/cash-touch)
+- [cash-true](https://npmjs.com/package/cash-true)
 - [cash-rm](https://npmjs.com/package/cash-rm)
 
 

--- a/packages/true/README.md
+++ b/packages/true/README.md
@@ -1,20 +1,20 @@
-# cash-kill
+# cash-true
 
 ---
 
 
-This is a cross-platform, 100% ES6 implementation of the Unix `kill` command.
+This is a cross-platform, 100% ES6 implementation of the Unix `true` command.
 
 ```bash
-npm install cash-kill -g
+npm install cash-true -g
 ```
 
-This will install `kill` globally in your system path.
+This will install `true` globally in your system path.
 
 For help on the command, type:
 
 ```bash
-> kill --help
+> true --help
 ```
 
 ## More

--- a/packages/true/bin/parser.js
+++ b/packages/true/bin/parser.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = function (args, command) {
+  args.splice(0, 2);
+  var pipes = (args.indexOf('|') > -1);
+  if (args.length === 0) {
+    // If we don't have to parse arguments, do
+    // the quickest load: just the raw js file
+    // of the command and nothing else.
+    var cmd = require('./../dist/commands/' + command)();
+    cmd.exec.call(console, {options: {}}, {});
+  } else if (pipes === false) {
+    // If we need to parse args for this
+    // command only, pull up vorpal and just load
+    // that one command.
+    var vorpal = require('vorpal')();
+    vorpal.api = {};
+    require('./../dist/commands/' + command)(vorpal);
+    args = args.join(' ');
+
+    // If we passed in a help request, load in
+    // the help file.
+    if (args.indexOf('help') > -1 || args.indexOf('?') > -1) {
+      let help;
+      try {
+        help = require('./../dist/help/' + command + '.js');
+        help = String(help).replace(/^\n|\n$/g, '');
+      } catch (e) {}
+      let cmdObj = vorpal.find(command);
+      if (cmdObj && help) {
+        cmdObj.help(function (argus, cb) {
+          cb(help);
+        })
+      }
+    }
+    vorpal.exec(command + ' ' + args);
+  } else {
+    // If we get into piping other commands,
+    // we need to go full bore and load the
+    // entire cash library.
+    // I guess we could technically parse all
+    // of the passed args, look for applicable
+    // commands and only load those, but that's
+    // some messy work for something that might
+    // not matter. If you're reading this and
+    // have deemed it matters, do a PR.
+    var cash = require('./../dist/index');
+    cash.vorpal.exec(command + ' ' + args.join(' '));
+  }
+};

--- a/packages/true/bin/true.js
+++ b/packages/true/bin/true.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./parser')(process.argv, 'true');

--- a/packages/true/dist/commands/true.js
+++ b/packages/true/dist/commands/true.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var interfacer = require('./../util/interfacer');
+
+var _true = {
+  exec: function exec() {
+    // Always return 0
+    return 0;
+  }
+};
+
+module.exports = function (vorpal) {
+  if (vorpal === undefined) {
+    return _true;
+  }
+  vorpal.api.true = _true;
+  vorpal.command('true').action(function (args, callback) {
+    return interfacer.call(this, {
+      command: _true,
+      callback: callback
+    });
+  });
+};

--- a/packages/true/dist/help/true.js
+++ b/packages/true/dist/help/true.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = "\nUsage: true [OPTION]\nDo nothing, successfully\n\nThis command simply exits with status zero (success).\n\n      --help   display this help and exit\n\nReport export bugs to <https://github.com/dthree/cash>\nCash home page: <http://cash.js.org/>\n";

--- a/packages/true/dist/preparser.js
+++ b/packages/true/dist/preparser.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// Replace out env variables.
+
+var parseEnvVariables = function parseEnvVariables(input) {
+  var referenceRegex = /\${([a-zA-Z_][a-zA-Z0-9_]*)}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
+
+  return input.replace(referenceRegex, function (varRef, capture1, capture2, capture3) {
+    var varName = capture1 || capture2 || capture3;
+    // Return the value of the variable, or the empty string if not there
+    return process.env.hasOwnProperty(varName) ? process.env[varName] : '';
+  });
+};
+
+var preparser = function preparser(input) {
+  input = parseEnvVariables(input);
+  return input;
+};
+
+module.exports = preparser;

--- a/packages/true/dist/util/interfacer.js
+++ b/packages/true/dist/util/interfacer.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Simple binding interface between
+ * each command's function and the caller
+ * of the command, whether by `cash.command`
+ * or by being invoked by Vorpal.
+ * This exists to abstract complexity
+ * and create a standard in interfacing
+ * commands acorss muliple execution paths.
+ *
+ * @param {Object} opt
+ * @api public
+ */
+
+module.exports = function (opt) {
+  var self = this;
+  var stdout = '';
+  opt.options = opt.options || {};
+  opt.callback = opt.callback || function () {};
+  opt.command = opt.command || {
+    exec: function exec() {}
+  };
+
+  var logger = {
+    log: function log(out) {
+      stdout += out + '\n';
+      if (opt.silent !== true) {
+        // process.stdout.write(out) // to do - handle newline problem.
+        self.log(out);
+      }
+    }
+  };
+
+  function onResult(result) {
+    result = result === undefined ? 0 : result;
+    opt.callback(null, stdout);
+    return stdout;
+  }
+
+  if (opt.async === true) {
+    return opt.command.exec.call(logger, opt.args, opt.options, onResult);
+  }
+  return onResult(opt.command.exec.call(logger, opt.args, opt.options));
+};

--- a/packages/true/package.json
+++ b/packages/true/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "cash-true",
+  "version": "0.0.1",
+  "description": "Cross-platform implementation of the Unix 'true' command.",
+  "main": "./dist/commands/true.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dthree/cash.git"
+  },
+  "keywords": [
+    "cash",
+    "terminal",
+    "emulator",
+    "cygwin",
+    "cli",
+    "windows",
+    "linux",
+    "unix",
+    "posix",
+    "bash",
+    "tty",
+    "util",
+    "vorpal",
+    "vorpal.js"
+  ],
+  "author": "dthree",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/dthree/cash/issues"
+  },
+  "homepage": "https://github.com/dthree/cash#readme",
+  "devDependencies": {},
+  "bin": {
+    "true": "./bin/true.js"
+  },
+  "dependencies": {
+    "vorpal": "^1.9.7"
+  },
+  "engines": {
+    "node": ">= 4",
+    "iojs": ">= 1.0.0"
+  },
+  "files": [
+    "dist",
+    "bin"
+  ]
+}

--- a/src/commands/false.js
+++ b/src/commands/false.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const interfacer = require('./../util/interfacer');
+
+const _false = {
+  exec() {
+    // Always return 1
+    return 1;
+  }
+};
+
+module.exports = function (vorpal) {
+  if (vorpal === undefined) {
+    return _false;
+  }
+  vorpal.api.false = _false;
+  vorpal
+    .command('false')
+    .action(function (args, callback) {
+      return interfacer.call(this, {
+        command: _false,
+        callback
+      });
+    });
+};

--- a/src/commands/true.js
+++ b/src/commands/true.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const interfacer = require('./../util/interfacer');
+
+const _true = {
+  exec() {
+    // Always return 0
+    return 0;
+  }
+};
+
+module.exports = function (vorpal) {
+  if (vorpal === undefined) {
+    return _true;
+  }
+  vorpal.api.true = _true;
+  vorpal
+    .command('true')
+    .action(function (args, callback) {
+      return interfacer.call(this, {
+        command: _true,
+        callback
+      });
+    });
+};

--- a/src/help.js
+++ b/src/help.js
@@ -10,6 +10,7 @@ const commands = [
   'cp [-fnr] source ... dest',
   'echo [-eE] [arg ...]',
   'export [-p][id=[value]]',
+  'false',
   'grep [-bHhinqsvw] [-m max] [--silent] [--include pattern] pattern [files ...]',
   'kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l',
   'less [files ...]',
@@ -20,6 +21,7 @@ const commands = [
   'rm [-frR] [files ...]',
   'sort [-chMnrR] [-o file] [files ...]',
   'touch [-acm] [-d date] [-r ref] [--time word] file ...',
+  'true',
   'unalias [-a] name [names ...]'
 ];
 

--- a/src/help/false.js
+++ b/src/help/false.js
@@ -6,6 +6,6 @@ This command simply exits with status 1 (failure).
 
       --help   display this help and exit
 
-Report export bugs to <https://github.com/dthree/cash>
+Report false bugs to <https://github.com/dthree/cash>
 Cash home page: <http://cash.js.org/>
 `;

--- a/src/help/false.js
+++ b/src/help/false.js
@@ -1,0 +1,11 @@
+module.exports = `
+Usage: false [OPTION]
+Do nothing, unsuccessfully
+
+This command simply exits with status 1 (failure).
+
+      --help   display this help and exit
+
+Report export bugs to <https://github.com/dthree/cash>
+Cash home page: <http://cash.js.org/>
+`;

--- a/src/help/true.js
+++ b/src/help/true.js
@@ -2,10 +2,10 @@ module.exports = `
 Usage: true [OPTION]
 Do nothing, successfully
 
-This command simply exits with status zero (success).
+This command simply exits with status 0 (success).
 
       --help   display this help and exit
 
-Report export bugs to <https://github.com/dthree/cash>
+Report true bugs to <https://github.com/dthree/cash>
 Cash home page: <http://cash.js.org/>
 `;

--- a/src/help/true.js
+++ b/src/help/true.js
@@ -1,0 +1,11 @@
+module.exports = `
+Usage: true [OPTION]
+Do nothing, successfully
+
+This command simply exits with status zero (success).
+
+      --help   display this help and exit
+
+Report export bugs to <https://github.com/dthree/cash>
+Cash home page: <http://cash.js.org/>
+`;

--- a/test/cat.js
+++ b/test/cat.js
@@ -4,7 +4,6 @@ require('assert');
 const should = require('should');
 const cash = require('../dist/index.js');
 const $ = require('shelljs');
-require('shelljs/global');
 
 describe('cat', function () {
   before(function () {

--- a/test/true.js
+++ b/test/true.js
@@ -1,0 +1,24 @@
+'use strict';
+
+require('assert');
+const should = require('should');
+const cash = require('../dist/index.js');
+
+describe('true', function () {
+  it('should exist and be a function', function () {
+    should.exist(cash.true);
+  });
+
+  it('should do nothing when called', function () {
+    const results = cash.true();
+    console.log(typeof results);
+    results.should.equal('');
+  });
+
+  describe('programmatic use', function () {
+    it('should execute in vorpal mode sync', function () {
+      const result = cash('true');
+      result.should.equal('');
+    });
+  });
+});


### PR DESCRIPTION
These are pretty similar, so I wrapped these into one PR.

`true` does nothing and returns status `0`. `false` does nothing and returns a non-zero status (for me on Ubuntu, it returns `1`).

I added unit tests, but I couldn't figure out how to check the actual return code (I only check the `stdout`). @dthree if you could direct me on how to check the return status, that would be good (if this sort of thing is even possible).

Also, it would be good if return status of the last command was saved somewhere globally (or inside `vorpal`, like the aliases are). This would let us represent `$?` (the return value of the last command).

I tried adding these as separate packages, but I'm not sure if I specified the correct dependencies. As far as I can tell, these should require minimal dependencies, so please check to see if I did this correctly, and I can revise accordingly.