### PR TITLE
Fix ls behavior for directory and file arguments

### DIFF
--- a/dist/commands/ls.js
+++ b/dist/commands/ls.js
@@ -62,7 +62,8 @@ var ls = {
       stdout += ls.execLsOnFiles('.', preSortedPaths.files, options).results;
     }
 
-    stdout += ls.formatAll(dirResults, options);
+    var dirOutput = ls.formatAll(dirResults, options, dirResults.length + preSortedPaths.files.length > 1);
+    stdout += stdout && dirOutput ? '\n\n' + dirOutput : dirOutput;
     if (strip(stdout).trim() !== '') {
       ls.self.log(String(stdout).replace(/\\/g, '/'));
     }
@@ -90,6 +91,8 @@ var ls = {
         ls.error(p, e);
       }
     }
+    files.sort();
+    dirs.sort();
 
     return { files: files, dirs: dirs };
   },
@@ -347,13 +350,14 @@ var ls = {
    *
    * @param {Array} results
    * @param {Object} options
+   * @param {boolean} showName
    * @return {String} stdout
    * @api private
    */
 
-  formatAll: function formatAll(results, options) {
+  formatAll: function formatAll(results, options, showName) {
     var stdout = '';
-    if (results.length > 1) {
+    if (showName) {
       for (var i = 0; i < results.length; ++i) {
         stdout += results[i].path + ':\n';
         if (options.l) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10,7 +10,7 @@ var delimiter = require('./delimiter.js');
 var path = require('path');
 var fs = require('fs');
 
-var cmds = undefined;
+var cmds = void 0;
 
 var app = {
 
@@ -39,7 +39,7 @@ var app = {
       out += str + '\n';
       return '';
     });
-    var commands = undefined;
+    var commands = void 0;
     if (tmpl) {
       // Render into a single string, inserting interpolated values.
       var interpVals = [].concat(Array.prototype.slice.call(arguments)).slice(1);
@@ -70,7 +70,7 @@ var app = {
       try {
         (function () {
           var mod = require('./commands/' + cmd + '.js');
-          var help = undefined;
+          var help = void 0;
           try {
             help = require('./help/' + cmd + '.js');
             help = String(help).replace(/^\n|\n$/g, '');
@@ -141,7 +141,7 @@ var app = {
     });
 
     // Load aliases
-    var all = undefined;
+    var all = void 0;
     try {
       all = JSON.parse(app.vorpal.localStorage.getItem('aliases') || []);
     } catch (e) {
@@ -196,10 +196,10 @@ var app = {
       return path.join(delimiter.getHomeDir(), str);
     });
 
-    for (var i = 0; i < locations.length; ++i) {
+    for (var _i = 0; _i < locations.length; ++_i) {
       try {
-        if (!fs.statSync(locations[i]).isDirectory()) {
-          app.vorpal.execSync('source ' + locations[i]);
+        if (!fs.statSync(locations[_i]).isDirectory()) {
+          app.vorpal.execSync('source ' + locations[_i]);
           break;
         }
       } catch (e) {

--- a/packages/ls/dist/commands/ls.js
+++ b/packages/ls/dist/commands/ls.js
@@ -62,7 +62,8 @@ var ls = {
       stdout += ls.execLsOnFiles('.', preSortedPaths.files, options).results;
     }
 
-    stdout += ls.formatAll(dirResults, options);
+    var dirOutput = ls.formatAll(dirResults, options, dirResults.length + preSortedPaths.files.length > 1);
+    stdout += stdout && dirOutput ? '\n\n' + dirOutput : dirOutput;
     if (strip(stdout).trim() !== '') {
       ls.self.log(String(stdout).replace(/\\/g, '/'));
     }
@@ -90,6 +91,8 @@ var ls = {
         ls.error(p, e);
       }
     }
+    files.sort();
+    dirs.sort();
 
     return { files: files, dirs: dirs };
   },
@@ -347,13 +350,14 @@ var ls = {
    *
    * @param {Array} results
    * @param {Object} options
+   * @param {boolean} showName
    * @return {String} stdout
    * @api private
    */
 
-  formatAll: function formatAll(results, options) {
+  formatAll: function formatAll(results, options, showName) {
     var stdout = '';
-    if (results.length > 1) {
+    if (showName) {
       for (var i = 0; i < results.length; ++i) {
         stdout += results[i].path + ':\n';
         if (options.l) {

--- a/src/commands/ls.js
+++ b/src/commands/ls.js
@@ -60,7 +60,8 @@ const ls = {
       stdout += ls.execLsOnFiles('.', preSortedPaths.files, options).results;
     }
 
-    stdout += ls.formatAll(dirResults, options);
+    const dirOutput = ls.formatAll(dirResults, options, (dirResults.length + preSortedPaths.files.length > 1));
+    stdout += (stdout && dirOutput) ? `\n\n${dirOutput}` : dirOutput;
     if (strip(stdout).trim() !== '') {
       ls.self.log(String(stdout).replace(/\\/g, '/'));
     }
@@ -89,6 +90,8 @@ const ls = {
         ls.error(p, e);
       }
     }
+    files.sort();
+    dirs.sort();
 
     return {files, dirs};
   },
@@ -348,13 +351,14 @@ const ls = {
    *
    * @param {Array} results
    * @param {Object} options
+   * @param {boolean} showName
    * @return {String} stdout
    * @api private
    */
 
-  formatAll(results, options) {
+  formatAll(results, options, showName) {
     let stdout = '';
-    if (results.length > 1) {
+    if (showName) {
       for (let i = 0; i < results.length; ++i) {
         stdout += `${results[i].path}:\n`;
         if (options.l) {

--- a/test/ls.js
+++ b/test/ls.js
@@ -66,6 +66,16 @@ if (os.platform() !== 'win32') {
         strip(res).should.equal(expected.subDirFlat);
       });
 
+      it('should list files and directories', function () {
+        const res = ls(['a.txt', 'b.tgz', './sub/']);
+        strip(res).should.equal(`a.txt  b.tgz\n\n./sub/:\n${expected.subDirFlat}`);
+      });
+
+      it('should sort files and directories, with files being first', function () {
+        const res = ls(['./sub', 'b.tgz', '.', 'a.txt']);
+        strip(res).should.equal(`a.txt  b.tgz\n\n.:\n${expected.rootDirFlat}\n./sub:\n${expected.subDirFlat}`);
+      });
+
       it('should list multiple directories', function () {
         const res = ls(['.', './sub']);
         strip(res).should.equal(`.:\n${expected.rootDirFlat}\n./sub:\n${expected.subDirFlat}`);


### PR DESCRIPTION
Fixes #61 

This also makes sure directories and files appear in sorted order (GNU ls seems to do this).

```bash
$ ls src bin/ README.md appveyor.yml
appveyor.yml  README.md

bin/:
alias.js  clear.js   false.js  less.js   parser.js  source.js  unalias.js
cash.js   cp.js      grep.js   ls.js     pwd.js     tail.js
cat.js    echo.js    head.js   mkdir.js  rm.js      touch.js
cd.js     export.js  kill.js   mv.js     sort.js    true.js

src:
commands  delimiter.js  help  help.js  index.js  lib  preparser.js  util  windows.js
```

Looks consistent with GNU ls `8.23`