### PR TITLE
chore: upgrade to ShellJS v0.7 and refactor accordingly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,7 +94,7 @@ gulp.task('packages', function () {
       readme = readme.replace(/\{package\-name\}/g, `cash-${name}`);
       readme = readme.replace(/\{command\-name\}/g, `${name}`);
       readme = readme.replace(/\{related\}/g, related);
-      readme.to(`${dir}/README.md`);
+      new $.ShellString(readme).to(`${dir}/README.md`);
       for (let i = 0; i < files.length; ++i) {
         $.cp('-f', files[i], `${dir}/${files[i]}`);
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gulp-eslint": "^2.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.2.5",
-    "shelljs": "^0.6.0",
+    "shelljs": "^0.7.0",
     "should": "^7.0.3",
     "webpack": "^1.12.13",
     "xo": "^0.12.1"

--- a/test/cat.js
+++ b/test/cat.js
@@ -7,13 +7,13 @@ const $ = require('shelljs');
 
 describe('cat', function () {
   before(function () {
-    'aardvark'.to('a.test');
-    'batman'.to('b.test');
-    'dont\n\n\neat\naardvarks\n\n\n'.to('c.test2');
+    new $.ShellString('aardvark').to('a.test');
+    new $.ShellString('batman').to('b.test');
+    new $.ShellString('dont\n\n\neat\naardvarks\n\n\n').to('c.test2');
   });
 
   after(function () {
-    $.rm(['a.test', 'b.test', 'c.test2']);
+    $.rm('a.test', 'b.test', 'c.test2');
   });
 
   it('should exist and be a function', function () {

--- a/test/cp.js
+++ b/test/cp.js
@@ -90,8 +90,8 @@ describe('cp', function () {
   });
 
   it('should clobber existing files', function () {
-    'foxes'.to('cp-d');
-    'elephants'.to('cp-e');
+    new $.ShellString('foxes').to('cp-d');
+    new $.ShellString('elephants').to('cp-e');
     cash.cp('cp-d cp-e');
     $.test('-e', 'cp-d').should.equal(true);
     $.cat('cp-e').should.equal('foxes');
@@ -99,8 +99,8 @@ describe('cp', function () {
 
   describe('-n', function () {
     it('should not clobber existing files', function () {
-      'foxes'.to('cp-d');
-      'elephants'.to('cp-e');
+      new $.ShellString('foxes').to('cp-d');
+      new $.ShellString('elephants').to('cp-e');
       cash.cp('cp-d cp-e', {noclobber: true}).should.equal('');
       $.test('-e', 'cp-d').should.equal(true);
       $.cat('cp-d').should.equal('foxes');
@@ -110,8 +110,8 @@ describe('cp', function () {
 
   describe('-f', function () {
     it('should overwrite -n', function () {
-      'foxes'.to('cp-d');
-      'elephants'.to('cp-e');
+      new $.ShellString('foxes').to('cp-d');
+      new $.ShellString('elephants').to('cp-e');
       cash.cp('cp-d cp-e', {noclobber: true, force: true});
       $.test('-e', 'cp-d').should.equal(true);
       $.cat('cp-e').should.equal('foxes');

--- a/test/head.js
+++ b/test/head.js
@@ -5,7 +5,6 @@ require('mocha');
 const should = require('should');
 const cash = require('../dist/index.js');
 const $ = require('shelljs');
-require('shelljs/global');
 
 const fxt = {
   ten: 'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n',
@@ -17,12 +16,12 @@ const fxt = {
 
 describe('head', function () {
   before(function () {
-    'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11'.to('eleven.test');
-    'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10'.to('ten.test');
+    new $.ShellString('line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11').to('eleven.test');
+    new $.ShellString('line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10').to('ten.test');
   });
 
   after(function () {
-    $.rm(['eleven.test', 'ten.test']);
+    $.rm('eleven.test', 'ten.test');
   });
 
   it('should exist', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ describe('cash', function () {
           console.error('warning: unable to save your cashrc file');
         }
       }
-      'touch fizzlecrumbs'.to(cashrcPath);
+      new $.ShellString('touch fizzlecrumbs').to(cashrcPath);
       cash = require('..');
     });
 

--- a/test/mv.js
+++ b/test/mv.js
@@ -86,8 +86,8 @@ describe('mv', function () {
   });
 
   it('should clobber existing files', function () {
-    'foxes'.to('mv-d');
-    'elephants'.to('mv-e');
+    new $.ShellString('foxes').to('mv-d');
+    new $.ShellString('elephants').to('mv-e');
     cash.mv('mv-d mv-e');
     $.test('-e', 'mv-d').should.equal(false);
     $.cat('mv-e').should.equal('foxes');
@@ -95,8 +95,8 @@ describe('mv', function () {
 
   describe('-n', function () {
     it('should not clobber existing files', function () {
-      'foxes'.to('mv-d');
-      'elephants'.to('mv-e');
+      new $.ShellString('foxes').to('mv-d');
+      new $.ShellString('elephants').to('mv-e');
       cash.mv('mv-d mv-e', {noclobber: true}).should.equal('');
       $.test('-e', 'mv-d').should.equal(true);
       $.cat('mv-d').should.equal('foxes');
@@ -106,8 +106,8 @@ describe('mv', function () {
 
   describe('-f', function () {
     it('should overwrite -n', function () {
-      'foxes'.to('mv-d');
-      'elephants'.to('mv-e');
+      new $.ShellString('foxes').to('mv-d');
+      new $.ShellString('elephants').to('mv-e');
       cash.mv('mv-d mv-e', {noclobber: true, force: true});
       $.test('-e', 'mv-d').should.equal(false);
       $.cat('mv-e').should.equal('foxes');

--- a/test/rm.js
+++ b/test/rm.js
@@ -5,22 +5,21 @@ const should = require('should');
 const cash = require('../dist/index.js');
 const fs = require('fs');
 const $ = require('shelljs');
-require('shelljs/global');
 
 describe('rm', function () {
   before(function () {
     $.mkdir('rm-test');
     $.mkdir('./rm-test/sub');
-    '1'.to('1.rm');
-    'a'.to('./rm-test/a.txt');
-    'b'.to('./rm-test/b.txt');
-    'c'.to('./rm-test/c.txt');
-    'd'.to('./rm-test/sub/d.txt');
-    'cow'.to('./rm-test/a.cows');
-    'cow'.to('./rm-test/b.cows');
-    'cow'.to('./rm-test/c.cows');
-    'goose'.to('./rm-test/a.goose');
-    'goose'.to('./rm-test/b.goose');
+    new $.ShellString('1').to('1.rm');
+    new $.ShellString('a').to('./rm-test/a.txt');
+    new $.ShellString('b').to('./rm-test/b.txt');
+    new $.ShellString('c').to('./rm-test/c.txt');
+    new $.ShellString('d').to('./rm-test/sub/d.txt');
+    new $.ShellString('cow').to('./rm-test/a.cows');
+    new $.ShellString('cow').to('./rm-test/b.cows');
+    new $.ShellString('cow').to('./rm-test/c.cows');
+    new $.ShellString('goose').to('./rm-test/a.goose');
+    new $.ShellString('goose').to('./rm-test/b.goose');
   });
 
   after(function () {
@@ -78,7 +77,7 @@ describe('rm', function () {
   describe('rm -f', function () {
     it('should remove a read only file with', function () {
       $.mkdir('-p', './rm-temp/readonly');
-      'asdf'.to('./rm-temp/readonly/file2');
+      new $.ShellString('asdf').to('./rm-temp/readonly/file2');
       fs.chmodSync('./rm-temp/readonly/file2', '0444'); // -r--r--r--
       cash.rm('./rm-temp/readonly/file2', {force: true});
       ($.ls('.').indexOf('./rm-temp/readonly/file2')).should.equal(-1);

--- a/test/sort.js
+++ b/test/sort.js
@@ -4,7 +4,6 @@ require('assert');
 const should = require('should');
 const cash = require('../dist/index.js');
 const $ = require('shelljs');
-require('shelljs/global');
 
 function sort(dir, opts) {
   opts = opts || {};
@@ -20,13 +19,13 @@ function sort(dir, opts) {
 describe('sort', function () {
   before(function (done) {
     setTimeout(function () {
-      'zaz\nsss\nqqq\n-zbz\nBBB\nddd\nCCC\n2bbb\nccc\n'.to('./default.sort');
-      '22 zaz\n33 sss\n11 qqq\n77 ccc\n55 BBB\nddd\nCCC\n2bbb\n-zbz\n'.to('./numeric.sort');
-      '1k\na 2G\n8k\n1M\n.8K\nddd\nCCC\n7bbb\n1bbb\n5M\n4G\n3T\n2.5P\n2E\n1Z\n6bbb\n5bbb\n-zbz\n'.to('./human.sort');
-      '4mar\nMarch\nMarc\napr\nAPR\ngoats\n56sevenjan\njan345kds\ndec\ndecem\nau\nAuGuSt\nAuGurt\naug\naugust\n'.to('./month.sort');
-      '1\n2\n3\n4\n5\n26\n7\n8\n9\n10\n11\n'.to('./disorder-numeric.sort');
-      'a\nb\nc\nd\nf\ne\ng\n'.to('./disorder.sort');
-      '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n'.to('./numbers.sort');
+      new $.ShellString('zaz\nsss\nqqq\n-zbz\nBBB\nddd\nCCC\n2bbb\nccc\n').to('./default.sort');
+      new $.ShellString('22 zaz\n33 sss\n11 qqq\n77 ccc\n55 BBB\nddd\nCCC\n2bbb\n-zbz\n').to('./numeric.sort');
+      new $.ShellString('1k\na 2G\n8k\n1M\n.8K\nddd\nCCC\n7bbb\n1bbb\n5M\n4G\n3T\n2.5P\n2E\n1Z\n6bbb\n5bbb\n-zbz\n').to('./human.sort');
+      new $.ShellString('4mar\nMarch\nMarc\napr\nAPR\ngoats\n56sevenjan\njan345kds\ndec\ndecem\nau\nAuGuSt\nAuGurt\naug\naugust\n').to('./month.sort');
+      new $.ShellString('1\n2\n3\n4\n5\n26\n7\n8\n9\n10\n11\n').to('./disorder-numeric.sort');
+      new $.ShellString('a\nb\nc\nd\nf\ne\ng\n').to('./disorder.sort');
+      new $.ShellString('1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n').to('./numbers.sort');
       done();
     }, 100);
   });

--- a/test/source.js
+++ b/test/source.js
@@ -15,10 +15,10 @@ describe('source', function () {
   before(function () {
     oldCwd = process.cwd();
     oldProcessEnv = process.env;
-    'echo "      hello world"\nalias foo bar\n'.to('a.sh');
-    `export FOO=hello
+    new $.ShellString('echo "      hello world"\nalias foo bar\n').to('a.sh');
+    new $.ShellString(`export FOO=hello
     export BAR=$FOO$FOO
-    cd ..`.to('b.sh');
+    cd ..`).to('b.sh');
     $.touch('nonreadable.txt');
     $.chmod('000', 'nonreadable.txt');
   });
@@ -26,7 +26,7 @@ describe('source', function () {
   after(function () {
     process.env = oldProcessEnv;
     $.chmod('555', 'nonreadable.txt'); // to allow deletion
-    $.rm('-f', ['a.sh', 'b.sh', 'nonreadable.txt']);
+    $.rm('-f', 'a.sh', 'b.sh', 'nonreadable.txt');
   });
 
   beforeEach(function () {

--- a/test/tail.js
+++ b/test/tail.js
@@ -15,12 +15,12 @@ const fxt = {
 
 describe('tail', function () {
   before(function () {
-    'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\n'.to('eleven.test');
-    'line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n'.to('ten.test');
+    new $.ShellString('line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\n').to('eleven.test');
+    new $.ShellString('line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n').to('ten.test');
   });
 
   after(function () {
-    $.rm(['eleven.test', 'ten.test']);
+    $.rm('eleven.test', 'ten.test');
   });
 
   it('should exist and be a function', function () {

--- a/test/util/util.js
+++ b/test/util/util.js
@@ -26,7 +26,7 @@ module.exports = {
         const next = files.shift();
         if (next) {
           filler = double(filler);
-          filler.to(dir + next);
+          new $.ShellString(filler).to(dir + next);
           setTimeout(function () {
             write();
           }, 10);


### PR DESCRIPTION
This refactors to use ShellJS v0.7. This also corrects every instance where `mystring.to()` was used, and makes sure it's using `new $.ShellString(mystring).to()`, since this is the recommended syntax for v0.7+.

The other changes (ex. `rm([file1, file2]);` -> `rm(file1, file2);`) were just stylistic preference, and can still be safely reverted if you prefer.