### PR TITLE
Use exit status 0 on `exit`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -137,7 +137,7 @@ var app = {
 
     app.vorpal.find('exit').action(function () {
       /* istanbul ignore next */
-      process.exit(1);
+      process.exit();
     });
 
     // Load aliases

--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,7 @@ const app = {
       .find('exit')
       .action(function () {
         /* istanbul ignore next */
-        process.exit(1);
+        process.exit();
       });
 
     // Load aliases


### PR DESCRIPTION
Typing `exit` should exit gracefully with exit status 0.